### PR TITLE
Fix: handle large Packages Manifest (>1MB) 

### DIFF
--- a/etc/portage/binhost/gh-upload.py
+++ b/etc/portage/binhost/gh-upload.py
@@ -1,8 +1,8 @@
 #!/bin/env python3
 # -*- coding: utf-8 -*-
 
-# Copyright 2019 by generik at spreequalle.de. All rights reserved.
-# This file is released under the "MIT License Agreement". Please see the LICENSE
+# Copyright 2020 by generik at spreequalle.de. All rights reserved.
+# This file is released under the "JSON License Agreement". Please see the LICENSE
 # file that should have been included as part of this package.
 
 import os

--- a/etc/portage/binhost/gh-upload.py
+++ b/etc/portage/binhost/gh-upload.py
@@ -49,31 +49,6 @@ def getXpakDesc():
 g = Github(gh_token)
 repo = g.get_repo(gh_repo)
 
-def get_blob_content(branch, path_name):
-    """
-    see:
-    https://github.com/PyGithub/PyGithub/issues/661
-    """
-    ref = repo.get_git_ref(f'heads/{branch}')
-    tree = repo.get_git_tree(ref.object.sha, recursive='/' in path_name).tree
-    sha = [x.sha for x in tree if x.path == path_name]
-    if not sha:
-        return None
-    return repo.get_git_blob(sha[0])
-
-def get_contents(branch, path_name):
-    """
-    First try to use traditional's github API to get package contents,
-    since this API can't fetch file size more than 1MB, use another API when failed.
-    """
-    try:
-        return repo.get_contents(path_name, ref=branch)
-    except GithubException:
-        blob = get_blob_content(branch, path_name)
-        if blob is None:
-            raise UnknownObjectException('unable to locate file: ' + path_name + ' in branch: ' + branch)
-        return blob
-
 # make sure we are working on an existent branch
 try:
     branch = repo.get_branch(gh_branch)
@@ -104,11 +79,17 @@ try:
     commitMsg = g_pkgName + g_xpakStatus
     with open(g_manifestPath, 'r') as file:
         g_manifestFile = file.read()
-    cnt = get_contents(gh_branch, g_manifest)
-    cnt = repo.update_file(g_manifest, commitMsg, g_manifestFile, cnt.sha, branch=gh_branch, committer=gh_author)
-except UnknownObjectException:
-    # create new file (Package)
-    cnt = repo.create_file(g_manifest, commitMsg, g_manifestFile, branch=gh_branch, committer=gh_author)
+
+    # receive git file/blob reference via git tree
+    ref = repo.get_git_ref(f'heads/{gh_branch}') # get branch ref
+    tree = repo.get_git_tree(ref.object.sha).tree # get git tree
+    sha = [x.sha for x in tree if x.path == g_manifest] # get file sha
+
+    if not sha:
+        # create new file (Packages)
+        repo.create_file(g_manifest, commitMsg, g_manifestFile, branch=gh_branch, committer=gh_author)
+    else:       
+        repo.update_file(g_manifest, commitMsg, g_manifestFile, sha[0], branch=gh_branch, committer=gh_author)
 except:
     print('error handling Manifest under: ' + g_manifestPath)
     exit(1)


### PR DESCRIPTION
As outlined [here](https://github.com/spreequalle/gentoo-binhost/commit/73da8ff31f37cf435d219ddf36bac1092d3db06a), GitHubs get_content() fails to fetch large files.

We now use [git_tree](https://docs.github.com/en/rest/reference/git#get-a-tree) to fetch the sha reference for the Packages Manifest.
